### PR TITLE
Adding missing params to getOrders

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,13 @@ Returns a list of orders that have been created from your checkouts.
 ```typescript
 /* 
     sinceDate?: string - yyyyMMdd
+    throughDate?: string - yyyyMMdd,
+    sinceOrderId?: string,
     statuses?: boolean
     missingMerchantOrderId?: boolean
 */
 
-zonos.getOrders({ sinceDate: "2022-01-01", statuses: true, missingMerchantOrderId: true });
+zonos.getOrders({sinceDate: "20230920", throughDate: "20230923", statuses: true});
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ Returns a list of orders that have been created from your checkouts.
 (requires api version 1)
 ```typescript
 /* 
-    sinceDate: string - yyyyMMdd
-    statuses?: boolean 
+    sinceDate?: string - yyyyMMdd
+    statuses?: boolean
+    missingMerchantOrderId?: boolean
 */
-zonos.getOrders("20220912", true);
+
+zonos.getOrders({ sinceDate: "2022-01-01", statuses: true, missingMerchantOrderId: true });
 ```
 
 <br>

--- a/zonos.ts
+++ b/zonos.ts
@@ -84,10 +84,13 @@ export class Zonos {
     }
 
     async getOrders(
-        sinceDate?: string,
-        statuses?: boolean,
-        missingMerchantOrderId?: boolean
+        options?: { 
+            sinceDate?: string, 
+            statuses?: boolean, 
+            missingMerchantOrderId?: boolean 
+        }
     ): Promise<any> {
+        const { sinceDate, statuses, missingMerchantOrderId } = options || {};
         return await this.directApiCall("orderNumbers", {
             sinceDate,
             statuses,

--- a/zonos.ts
+++ b/zonos.ts
@@ -86,13 +86,17 @@ export class Zonos {
     async getOrders(
         options?: { 
             sinceDate?: string, 
+            throughDate?: string,
+            sinceOrderId?: string,
             statuses?: boolean, 
-            missingMerchantOrderId?: boolean 
+            missingMerchantOrderId?: boolean,
         }
     ): Promise<any> {
-        const { sinceDate, statuses, missingMerchantOrderId } = options || {};
+        const { sinceDate, throughDate, sinceOrderId, statuses, missingMerchantOrderId } = options || {};
         return await this.directApiCall("orderNumbers", {
             sinceDate,
+            throughDate,
+            sinceOrderId,
             statuses,
             missingMerchantOrderId,
         });


### PR DESCRIPTION
This PR adds two missing params to getOrders and modifies the function to accept an options object.